### PR TITLE
Scorecard POC: added border animation while editing items for DD, MS, Outputs

### DIFF
--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryContainer/DataDictionaryContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryContainer/DataDictionaryContainer.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import { Bullseye, Button, Flex, FlexItem } from "@patternfly/react-core";
 import { BoltIcon, PlusIcon, SortIcon } from "@patternfly/react-icons";
-import { v4 as uuid } from "uuid";
 import { CSSTransition, SwitchTransition } from "react-transition-group";
 
 import DataTypeItem from "../DataTypeItem/DataTypeItem";
@@ -206,7 +205,7 @@ const DataDictionaryContainer = ({ dataDictionary, onUpdate }: DataDictionaryCon
                         <DataTypeItem
                           dataType={item}
                           index={index}
-                          key={uuid()}
+                          key={item.name}
                           onSave={handleSave}
                           onEdit={handleEdit}
                           onDelete={handleDelete}

--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.scss
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.scss
@@ -1,10 +1,12 @@
 .data-type-item {
   min-height: 70px;
   border: 1px solid var(--pf-global--BorderColor--100);
-  padding: 1em;
   background-color: #ffffff;
   margin-bottom: 1em;
   user-select: none;
+  &__inner {
+    padding: 1em;
+  }
   // write the following better
   span,
   strong {

--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
@@ -54,7 +54,7 @@ const DataTypeItem = (props: DataTypeItemProps) => {
       console.log("click outside");
       onOutsideClick();
     },
-    { eventTypes: ["click"], ignoreClass: "data-type-item__type-select__option" }
+    { eventTypes: ["click"], ignoreClass: "data-type-item__type-select__option", disabled: editing !== index }
   );
 
   const handleNameChange = (value: string) => {
@@ -119,94 +119,92 @@ const DataTypeItem = (props: DataTypeItemProps) => {
   }, [editing]);
 
   return (
-    <>
+    <article className={`data-type-item editable ${editing === index ? "editing" : ""} data-type-item-n${index}`}>
       {editing === index && (
-        <article className={`data-type-item editing data-type-item-n${index}`}>
-          <section ref={ref}>
-            <Form onSubmit={handleSave}>
-              <Stack hasGutter={true}>
-                <StackItem>
-                  <Split hasGutter={true}>
-                    <SplitItem>
-                      <FormGroup
-                        fieldId="name"
-                        helperTextInvalid="Name already used by another Data Type"
+        <section className="data-type-item__inner" ref={ref}>
+          <Form onSubmit={handleSave}>
+            <Stack hasGutter={true}>
+              <StackItem>
+                <Split hasGutter={true}>
+                  <SplitItem>
+                    <FormGroup
+                      fieldId="name"
+                      helperTextInvalid="Name already used by another Data Type"
+                      validated={validation}
+                      style={{ width: 280 }}
+                    >
+                      <TextInput
+                        type="text"
+                        id="name"
+                        name="name"
+                        value={name}
+                        onChange={handleNameChange}
+                        placeholder="Name"
                         validated={validation}
-                        style={{ width: 280 }}
-                      >
-                        <TextInput
-                          type="text"
-                          id="name"
-                          name="name"
-                          value={name}
-                          onChange={handleNameChange}
-                          placeholder="Name"
-                          validated={validation}
-                          onBlur={handleNameSave}
-                          autoComplete="off"
+                        onBlur={handleNameSave}
+                        autoComplete="off"
+                      />
+                    </FormGroup>
+                  </SplitItem>
+                  <SplitItem>
+                    <Select
+                      variant={SelectVariant.single}
+                      aria-label="Select Input"
+                      onToggle={typeToggle}
+                      onSelect={typeSelect}
+                      selections={typeSelection}
+                      isOpen={isTypeSelectOpen}
+                      placeholder="Type"
+                      className="data-type-item__type-select"
+                    >
+                      {typeOptions.map((option, optionIndex) => (
+                        <SelectOption
+                          key={optionIndex}
+                          value={option.value}
+                          className="data-type-item__type-select__option"
                         />
-                      </FormGroup>
-                    </SplitItem>
-                    <SplitItem>
-                      <Select
-                        variant={SelectVariant.single}
-                        aria-label="Select Input"
-                        onToggle={typeToggle}
-                        onSelect={typeSelect}
-                        selections={typeSelection}
-                        isOpen={isTypeSelectOpen}
-                        placeholder="Type"
-                        className="data-type-item__type-select"
+                      ))}
+                    </Select>
+                  </SplitItem>
+                  <SplitItem isFilled={true}>&nbsp;</SplitItem>
+                </Split>
+              </StackItem>
+              <StackItem>
+                <Split hasGutter={true}>
+                  <SplitItem>
+                    {dataType.constraints === undefined && (
+                      <Button
+                        variant="link"
+                        icon={<AngleRightIcon />}
+                        isInline={true}
+                        iconPosition="right"
+                        onClick={handleConstraints}
+                        isDisabled={name.trim().length === 0 || typeSelection === "boolean"}
                       >
-                        {typeOptions.map((option, optionIndex) => (
-                          <SelectOption
-                            key={optionIndex}
-                            value={option.value}
-                            className="data-type-item__type-select__option"
-                          />
-                        ))}
-                      </Select>
-                    </SplitItem>
-                    <SplitItem isFilled={true}>&nbsp;</SplitItem>
-                  </Split>
-                </StackItem>
-                <StackItem>
-                  <Split hasGutter={true}>
-                    <SplitItem>
-                      {dataType.constraints === undefined && (
+                        <span>Add Constraints</span>
+                      </Button>
+                    )}
+                    {dataType.constraints !== undefined && (
+                      <>
+                        <span>Constraints</span>
                         <Button
                           variant="link"
-                          icon={<AngleRightIcon />}
-                          isInline={true}
-                          iconPosition="right"
                           onClick={handleConstraints}
                           isDisabled={name.trim().length === 0 || typeSelection === "boolean"}
                         >
-                          <span>Add Constraints</span>
+                          <ConstraintsLabel constraints={dataType.constraints} />
                         </Button>
-                      )}
-                      {dataType.constraints !== undefined && (
-                        <>
-                          <span>Constraints</span>
-                          <Button
-                            variant="link"
-                            onClick={handleConstraints}
-                            isDisabled={name.trim().length === 0 || typeSelection === "boolean"}
-                          >
-                            <ConstraintsLabel constraints={dataType.constraints} />
-                          </Button>
-                        </>
-                      )}
-                    </SplitItem>
-                  </Split>
-                </StackItem>
-              </Stack>
-            </Form>
-          </section>
-        </article>
+                      </>
+                    )}
+                  </SplitItem>
+                </Split>
+              </StackItem>
+            </Stack>
+          </Form>
+        </section>
       )}
       {editing !== index && (
-        <article className={`data-type-item data-type-item-n${index}`} onClick={handleEditStatus}>
+        <section className="data-type-item__inner" onClick={handleEditStatus}>
           <Flex alignItems={{ default: "alignItemsCenter" }} style={{ height: "100%" }}>
             <FlexItem>
               <strong>{name}</strong>
@@ -228,9 +226,9 @@ const DataTypeItem = (props: DataTypeItemProps) => {
               </Button>
             </FlexItem>
           </Flex>
-        </article>
+        </section>
       )}
-    </>
+    </article>
   );
 };
 

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.scss
@@ -15,24 +15,21 @@
  */
 
 .editor {
-
   position: relative;
   height: calc(100vh - 48px);
-
 }
 
 .editable {
   cursor: pointer;
-}
+  transition: border-left 0.12s ease-in;
 
-.editable:hover {
-  box-shadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
+  &:hover {
+    box-shadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
+  }
 }
 
 .editing {
   cursor: auto;
   box-shadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
-  border-left-color: var(--pf-global--active-color--100);
-  border-left-width: var(--pf-global--BorderWidth--l);
-  border-left-style: solid;
+  border-left: var(--pf-global--BorderWidth--lg) solid var(--pf-global--active-color--100);
 }

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
@@ -43,7 +43,6 @@ import { Operation } from "../../EditorScorecard";
 
 interface OutputFieldEditRowProps {
   activeOperation: Operation;
-  activeOutputFieldIndex: number | undefined;
   name: ValidatedType<FieldName> | undefined;
   setName: (name: ValidatedType<FieldName>) => void;
   dataType: DataType;
@@ -94,7 +93,6 @@ const dataTypes = [
 export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
   const {
     activeOperation,
-    activeOutputFieldIndex,
     name,
     setName,
     dataType,
@@ -128,7 +126,7 @@ export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
   };
 
   const ref = useOnclickOutside(
-    event => {
+    () => {
       if (name?.valid) {
         onCommitAndClose();
       } else {
@@ -142,9 +140,9 @@ export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
   );
 
   return (
-    <article
+    <section
       ref={ref}
-      className={`output-item output-item-n${activeOutputFieldIndex} editable editing`}
+      className={`output-item__inner`}
       tabIndex={0}
       onKeyDown={e => {
         if (e.key === "Escape") {
@@ -178,7 +176,7 @@ export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
                       valid: validateOutputName(e)
                     });
                   }}
-                  onBlur={e => {
+                  onBlur={() => {
                     if (name?.valid) {
                       onCommit({
                         name: name?.value as FieldName
@@ -248,6 +246,6 @@ export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
           </Split>
         </StackItem>
       </Stack>
-    </article>
+    </section>
   );
 };

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.scss
@@ -1,10 +1,12 @@
 .output-item {
   min-height: 70px;
   border: 1px solid var(--pf-global--BorderColor--100);
-  padding: 1em;
   background-color: #ffffff;
   margin-bottom: 1em;
   user-select: none;
+  &__inner {
+    padding: 1em;
+  }
   // write the following better
   span,
   strong {

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
@@ -18,10 +18,8 @@ import { Label, Split, SplitItem } from "@patternfly/react-core";
 import { DataType, FieldName, OpType, RankOrder, ResultFeature } from "@kogito-tooling/pmml-editor-marshaller";
 import { OutputFieldRowAction, OutputLabels } from "../atoms";
 import "./OutputFieldRow.scss";
-import { ValidatedType } from "../../../types";
 
 interface OutputFieldRowProps {
-  activeOutputFieldIndex: number;
   name: FieldName | undefined;
   dataType: DataType;
   optype: OpType | undefined;
@@ -38,7 +36,6 @@ interface OutputFieldRowProps {
 
 export const OutputFieldRow = (props: OutputFieldRowProps) => {
   const {
-    activeOutputFieldIndex,
     name,
     dataType,
     optype,
@@ -54,8 +51,8 @@ export const OutputFieldRow = (props: OutputFieldRowProps) => {
   } = props;
 
   return (
-    <article
-      className={`output-item output-item-n${activeOutputFieldIndex} editable`}
+    <section
+      className={`output-item__inner`}
       onClick={onEditOutputField}
       tabIndex={0}
       onKeyDown={e => {
@@ -89,6 +86,6 @@ export const OutputFieldRow = (props: OutputFieldRowProps) => {
           <OutputFieldRowAction onDeleteOutputField={onDeleteOutputField} />
         </SplitItem>
       </Split>
-    </article>
+    </section>
   );
 };

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
@@ -113,8 +113,8 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
     }
   };
 
-  const onValidateOutputFieldName = (index: number | undefined, name: string | undefined): boolean => {
-    return validateOutputFieldName(index, name);
+  const onValidateOutputFieldName = (index: number | undefined, nameToValidate: string | undefined): boolean => {
+    return validateOutputFieldName(index, nameToValidate);
   };
 
   return (
@@ -125,13 +125,16 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
       }}
     >
       <section>
-        {outputs.map((o, index) => {
-          if (activeOutputFieldIndex === index) {
-            return (
+        {outputs.map((o, index) => (
+          <article
+            className={`output-item output-item-n${activeOutputFieldIndex} editable ${
+              activeOutputFieldIndex === index ? "editing" : ""
+            }`}
+            key={o.name.value}
+          >
+            {activeOutputFieldIndex === index && (
               <OutputFieldEditRow
-                key={index}
                 activeOperation={activeOperation}
-                activeOutputFieldIndex={index}
                 name={name}
                 setName={setName}
                 dataType={dataType}
@@ -158,12 +161,9 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
                 onCommit={onCommit}
                 onCancel={onCancel}
               />
-            );
-          } else {
-            return (
+            )}
+            {activeOutputFieldIndex !== index && (
               <OutputFieldRow
-                key={index}
-                activeOutputFieldIndex={index}
                 name={o.name}
                 dataType={o.dataType}
                 optype={o.optype}
@@ -177,9 +177,9 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
                 onEditOutputField={() => onEditOutputField(index)}
                 onDeleteOutputField={() => onDelete(index)}
               />
-            );
-          }
-        })}
+            )}
+          </article>
+        ))}
       </section>
       {outputs.length === 0 && (
         <Bullseye>


### PR DESCRIPTION
hi @manstis,
I thought this would have been easier. I had to lift up the `editing` css class, switching between two different elements prevented from displaying transition animations.