### PR TITLE
Scorecard POC: fixing ouput rank not displayed when 0

### DIFF
--- a/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabels.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabels.tsx
@@ -37,7 +37,7 @@ export const OutputLabels = (props: OutputLabelsProps) => {
       {targetField && OutputFieldLabel("TargetField", targetField)}
       {feature && OutputFieldLabel("Feature", feature)}
       {value && OutputFieldLabel("Value", value)}
-      {rank && OutputFieldLabel("Rank", rank)}
+      {rank !== undefined && OutputFieldLabel("Rank", rank)}
       {rankOrder && OutputFieldLabel("RankOrder", rankOrder)}
       {segmentId && OutputFieldLabel("SegmentId", segmentId)}
       {isFinalResult && OutputFieldLabel("FinalResult", isFinalResult.toString())}

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldExtendedProperties.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldExtendedProperties.tsx
@@ -70,11 +70,11 @@ export const OutputFieldExtendedProperties = (props: OutputFieldExtendedProperti
     commit
   } = props;
 
-  const toNumber = (value: string): number | undefined => {
-    if (value === "") {
+  const toNumber = (_value: string): number | undefined => {
+    if (_value === "") {
       return undefined;
     }
-    const n = Number(value);
+    const n = Number(_value);
     if (isNaN(n)) {
       return undefined;
     }
@@ -219,7 +219,7 @@ export const OutputFieldExtendedProperties = (props: OutputFieldExtendedProperti
           id="output-rank"
           name="output-rank"
           aria-describedby="output-rank-helper"
-          value={rank}
+          value={rank ?? ""}
           onChange={e => setRank(toNumber(e))}
           onBlur={e =>
             commit({
@@ -245,7 +245,7 @@ export const OutputFieldExtendedProperties = (props: OutputFieldExtendedProperti
           id="output-segmentId"
           name="output-segmentId"
           aria-describedby="output-segmentId-helper"
-          value={segmentId}
+          value={segmentId ?? ""}
           onChange={e => setSegmentId(e)}
           onBlur={e =>
             commit({


### PR DESCRIPTION
hi @manstis,
If the rank in outputs is `0`, it is rendered as is instead of as `Label` because it's a _falsy_ value.
I also fixed a couple of `uncontrolled components` console errors.