### PR TITLE
Scorecard POC: Outputs bulk add

### DIFF
--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
@@ -90,7 +90,7 @@ const dataTypes = [
   "dateTimeSecondsSince[1980]"
 ];
 
-export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
+const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
   const {
     activeOperation,
     name,
@@ -249,3 +249,5 @@ export const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
     </section>
   );
 };
+
+export default OutputFieldEditRow;

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
@@ -34,7 +34,7 @@ interface OutputFieldRowProps {
   onDeleteOutputField: () => void;
 }
 
-export const OutputFieldRow = (props: OutputFieldRowProps) => {
+const OutputFieldRow = (props: OutputFieldRowProps) => {
   const {
     name,
     dataType,
@@ -89,3 +89,5 @@ export const OutputFieldRow = (props: OutputFieldRowProps) => {
     </section>
   );
 };
+
+export default OutputFieldRow;

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
@@ -24,11 +24,12 @@ import {
   RankOrder,
   ResultFeature
 } from "@kogito-tooling/pmml-editor-marshaller";
-import { OutputFieldEditRow, OutputFieldRow } from "../molecules";
 import "./OutputFieldsTable.scss";
 import { Operation } from "../../EditorScorecard";
 import { EmptyStateNoOutput } from "./EmptyStateNoOutput";
 import { ValidatedType } from "../../../types";
+import OutputFieldRow from "../molecules/OutputFieldRow";
+import OutputFieldEditRow from "../molecules/OutputFieldEditRow";
 
 interface OutputFieldsTableProps {
   activeOperation: Operation;
@@ -64,7 +65,7 @@ interface OutputFieldsTableProps {
   onCancel: () => void;
 }
 
-export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
+const OutputFieldsTable = (props: OutputFieldsTableProps) => {
   const {
     activeOperation,
     onAddOutputField,
@@ -130,7 +131,7 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
             className={`output-item output-item-n${activeOutputFieldIndex} editable ${
               activeOutputFieldIndex === index ? "editing" : ""
             }`}
-            key={o.name.value}
+            key={o.name as string}
           >
             {activeOutputFieldIndex === index && (
               <OutputFieldEditRow
@@ -189,3 +190,5 @@ export const OutputFieldsTable = (props: OutputFieldsTableProps) => {
     </Form>
   );
 };
+
+export default OutputFieldsTable;

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsBatchAdd.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsBatchAdd.scss
@@ -1,0 +1,7 @@
+.outputs-container {
+  &__multiple-outputs {
+    min-height: 200px;
+    font-family: monospace;
+    font-size: var(--pf-global--FontSize--lg);
+  }
+}

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsBatchAdd.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsBatchAdd.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  Stack,
+  StackItem,
+  Text,
+  TextArea,
+  TextContent,
+  TextVariants
+} from "@patternfly/react-core";
+import "./OutputsBatchAdd.scss";
+
+interface OutputsBatchAddProps {
+  onAdd: (types: string) => void;
+  onCancel: () => void;
+}
+
+const OutputsBatchAdd = ({ onAdd, onCancel }: OutputsBatchAddProps) => {
+  const [input, setInput] = useState("");
+  const [inputValidation, setInputValidation] = useState<"success" | "error" | "default">("default");
+
+  useEffect(() => {
+    document.querySelector<HTMLInputElement>(`#outputs`)?.focus();
+  }, []);
+
+  const handleInputChange = (value: string) => {
+    setInput(value);
+  };
+
+  const validateInput = () => {
+    const validation = input.trim().length > 0 ? "success" : "error";
+    setInputValidation(validation);
+    return validation;
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    if (validateInput() === "success") {
+      onAdd(input);
+    }
+    event.preventDefault();
+  };
+
+  return (
+    <section>
+      <Stack hasGutter={true}>
+        <StackItem>
+          <TextContent>
+            <Text component={TextVariants.h3}>Add Multiple Output Fields</Text>
+            <Text component={TextVariants.p}>
+              You can add multiple outputs by entering their names below. Add them one per line.
+              <br />
+              They will be created with the default type of <em>String</em>. You will be able to edit them later.
+            </Text>
+          </TextContent>
+        </StackItem>
+        <StackItem>
+          <Form onSubmit={handleSubmit} style={{ gridGap: 0 }}>
+            <FormGroup
+              label="Outputs"
+              fieldId="outputs"
+              isRequired={true}
+              validated={inputValidation}
+              helperTextInvalid={"Please enter at least one Output name"}
+            >
+              <TextArea
+                className="outputs-container__multiple-outputs"
+                value={input}
+                onChange={handleInputChange}
+                name="outputs"
+                isRequired={true}
+                id="outputs"
+                placeholder={"First Output\nSecond Output\n..."}
+              />
+            </FormGroup>
+            <ActionGroup>
+              <Button variant="primary" type="submit">
+                Add Them
+              </Button>
+              <Button variant="link" onClick={() => onCancel()}>
+                Never mind
+              </Button>
+            </ActionGroup>
+          </Form>
+        </StackItem>
+      </Stack>
+    </section>
+  );
+};
+
+export default OutputsBatchAdd;

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.scss
@@ -15,12 +15,12 @@
  */
 
 .outputs-container {
-
+  height: 60vh;
   &__overview {
+    height: calc(60vh - 52px);
     overflow-y: auto;
     padding: 1em;
     background-color: var(--pf-global--BackgroundColor--200);
-    height: 60vh;
 
     &-enter {
       opacity: 0;
@@ -45,7 +45,7 @@
     overflow-y: auto;
     padding: 1em;
     background-color: var(--pf-global--BackgroundColor--200);
-    height: calc(60vh - 46px);
+    height: calc(60vh - 52px);
 
     &-enter {
       transform: translateX(100px);
@@ -66,6 +66,27 @@
     &-exit-active {
       opacity: 0;
       transform: translateX(44px);
+      transition: all 100ms;
+    }
+  }
+
+  &__batch-add {
+    &-enter {
+      transform: translateY(-50px);
+      opacity: 0;
+    }
+    &-enter-active {
+      transform: translateY(0);
+      opacity: 1;
+      transition: all 230ms;
+    }
+    &-exit {
+      transform: translateY(0);
+      opacity: 1;
+    }
+    &-exit-active {
+      opacity: 0;
+      transform: translateY(-21px);
       transition: all 100ms;
     }
   }

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
@@ -24,17 +24,20 @@ import {
   RankOrder,
   ResultFeature
 } from "@kogito-tooling/pmml-editor-marshaller";
-import { Button, Stack, StackItem, TextContent, Title } from "@patternfly/react-core";
-import { ArrowAltCircleLeftIcon, PlusIcon } from "@patternfly/react-icons";
-import { OutputFieldsTable } from "./OutputFieldsTable";
-import { Operation } from "../../EditorScorecard";
-import "./OutputsContainer.scss";
+import { Button, Flex, FlexItem, Stack, StackItem, TextContent, Title } from "@patternfly/react-core";
+import { ArrowAltCircleLeftIcon, BoltIcon, PlusIcon } from "@patternfly/react-icons";
+import { isEqual } from "lodash";
 import { CSSTransition, SwitchTransition } from "react-transition-group";
+import OutputFieldsTable from "./OutputFieldsTable";
+import OutputsBatchAdd from "./OutputsBatchAdd";
+import { Operation } from "../../EditorScorecard";
 import { OutputFieldExtendedProperties } from "./OutputFieldExtendedProperties";
 import { ValidatedType } from "../../../types";
-import { isEqual } from "lodash";
 import get = Reflect.get;
 import set = Reflect.set;
+import "./OutputsContainer.scss";
+import { Actions } from "../../../reducers";
+import { useDispatch } from "react-redux";
 
 interface OutputsContainerProps {
   modelIndex: number;
@@ -46,10 +49,18 @@ interface OutputsContainerProps {
   commit: (index: number | undefined, outputField: OutputField) => void;
 }
 
-type OutputsViewSection = "overview" | "extended-properties";
+type OutputsViewSection = "overview" | "extended-properties" | "batch-add";
 
 export const OutputsContainer = (props: OutputsContainerProps) => {
-  const { activeOperation, setActiveOperation, output, validateOutputFieldName, deleteOutputField, commit } = props;
+  const {
+    modelIndex,
+    activeOperation,
+    setActiveOperation,
+    output,
+    validateOutputFieldName,
+    deleteOutputField,
+    commit
+  } = props;
 
   const [editItemIndex, setEditItemIndex] = useState<number | undefined>(undefined);
   const [name, setName] = useState<ValidatedType<FieldName> | undefined>();
@@ -62,15 +73,24 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
   const [rankOrder, setRankOrder] = useState<RankOrder | undefined>();
   const [segmentId, setSegmentId] = useState<string | undefined>();
   const [isFinalResult, setIsFinalResult] = useState<boolean | undefined>();
-
   const [viewSection, setViewSection] = useState<OutputsViewSection>("overview");
 
+  const dispatch = useDispatch();
+
   const getTransition = (_viewSection: OutputsViewSection) => {
-    if (_viewSection === "overview") {
-      return "outputs-container__overview";
-    } else {
-      return "outputs-container__extended-properties";
+    let cssClass;
+    switch (_viewSection) {
+      case "overview":
+        cssClass = "outputs-container__overview";
+        break;
+      case "extended-properties":
+        cssClass = "outputs-container__extended-properties";
+        break;
+      case "batch-add":
+        cssClass = "outputs-container__batch-add";
+        break;
     }
+    return cssClass;
   };
 
   const addOutputField = () => {
@@ -93,7 +113,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
         isFinalResult: undefined
       });
       setName({ value: newOutputFieldName, valid: true });
-      setDataType("boolean");
+      setDataType("string");
       setOptype(undefined);
       setTargetField(undefined);
       setFeature(undefined);
@@ -120,6 +140,18 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
     setSegmentId(outputField.segmentId);
     setIsFinalResult(outputField.isFinalResult);
     setActiveOperation(Operation.UPDATE_OUTPUT);
+  };
+
+  const addBatchOutputs = (outputs: string) => {
+    const outputsNames = outputs.split("\n").filter(item => item.trim().length > 0);
+    dispatch({
+      type: Actions.AddBatchOutputs,
+      payload: {
+        modelIndex: modelIndex,
+        outputFields: outputsNames
+      }
+    });
+    setViewSection("overview");
   };
 
   const onCommitAndClose = () => {
@@ -159,15 +191,30 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
             {viewSection === "overview" && (
               <Stack hasGutter={true}>
                 <StackItem>
-                  <Button
-                    variant="primary"
-                    onClick={addOutputField}
-                    isDisabled={activeOperation !== Operation.NONE}
-                    icon={<PlusIcon />}
-                    iconPosition="left"
-                  >
-                    Add Output
-                  </Button>
+                  <Flex>
+                    <FlexItem>
+                      <Button
+                        variant="primary"
+                        onClick={addOutputField}
+                        isDisabled={activeOperation !== Operation.NONE}
+                        icon={<PlusIcon />}
+                        iconPosition="left"
+                      >
+                        Add Output
+                      </Button>
+                    </FlexItem>
+                    <FlexItem>
+                      <Button
+                        variant="secondary"
+                        onClick={() => setViewSection("batch-add")}
+                        isDisabled={activeOperation !== Operation.NONE}
+                        icon={<BoltIcon />}
+                        iconPosition="left"
+                      >
+                        Add Multiple Outputs
+                      </Button>
+                    </FlexItem>
+                  </Flex>
                 </StackItem>
                 <StackItem className="outputs-container__overview">
                   <OutputFieldsTable
@@ -211,7 +258,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
                 <StackItem>
                   <TextContent>
                     <Title size="lg" headingLevel="h1">
-                      <a onClick={e => setViewSection("overview")}>{name?.value}</a>&nbsp;/&nbsp;Properties
+                      <a onClick={() => setViewSection("overview")}>{name?.value}</a>&nbsp;/&nbsp;Properties
                     </Title>
                   </TextContent>
                 </StackItem>
@@ -239,7 +286,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
                 <StackItem>
                   <Button
                     variant="primary"
-                    onClick={e => setViewSection("overview")}
+                    onClick={() => setViewSection("overview")}
                     icon={<ArrowAltCircleLeftIcon />}
                     iconPosition="left"
                   >
@@ -247,6 +294,11 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
                   </Button>
                 </StackItem>
               </Stack>
+            )}
+            {viewSection === "batch-add" && (
+              <>
+                <OutputsBatchAdd onAdd={addBatchOutputs} onCancel={() => setViewSection("overview")} />
+              </>
             )}
           </>
         </CSSTransition>

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
@@ -296,9 +296,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
               </Stack>
             )}
             {viewSection === "batch-add" && (
-              <>
-                <OutputsBatchAdd onAdd={addBatchOutputs} onCancel={() => setViewSection("overview")} />
-              </>
+              <OutputsBatchAdd onAdd={addBatchOutputs} onCancel={() => setViewSection("overview")} />
             )}
           </>
         </CSSTransition>

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
@@ -15,6 +15,11 @@
  */
 import * as React from "react";
 import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { isEqual } from "lodash";
+import { CSSTransition, SwitchTransition } from "react-transition-group";
+import { Button, Flex, FlexItem, Stack, StackItem, TextContent, Title } from "@patternfly/react-core";
+import { ArrowAltCircleLeftIcon, BoltIcon, PlusIcon } from "@patternfly/react-icons";
 import {
   DataType,
   FieldName,
@@ -24,20 +29,15 @@ import {
   RankOrder,
   ResultFeature
 } from "@kogito-tooling/pmml-editor-marshaller";
-import { Button, Flex, FlexItem, Stack, StackItem, TextContent, Title } from "@patternfly/react-core";
-import { ArrowAltCircleLeftIcon, BoltIcon, PlusIcon } from "@patternfly/react-icons";
-import { isEqual } from "lodash";
-import { CSSTransition, SwitchTransition } from "react-transition-group";
+import { ValidatedType } from "../../../types";
+import { Actions } from "../../../reducers";
 import OutputFieldsTable from "./OutputFieldsTable";
 import OutputsBatchAdd from "./OutputsBatchAdd";
 import { Operation } from "../../EditorScorecard";
 import { OutputFieldExtendedProperties } from "./OutputFieldExtendedProperties";
-import { ValidatedType } from "../../../types";
+import "./OutputsContainer.scss";
 import get = Reflect.get;
 import set = Reflect.set;
-import "./OutputsContainer.scss";
-import { Actions } from "../../../reducers";
-import { useDispatch } from "react-redux";
 
 interface OutputsContainerProps {
   modelIndex: number;

--- a/packages/pmml-editor/src/editor/reducers/Actions.ts
+++ b/packages/pmml-editor/src/editor/reducers/Actions.ts
@@ -48,6 +48,7 @@ export enum Actions {
   SetDataFieldName = "SET_DATA_FIELD_NAME",
   SetHeaderDescription = "SET_HEADER_DESCRIPTION",
   AddOutput = "OUTPUT_ADD",
+  AddBatchOutputs = "OUTPUT_BATCH_ADD",
   UpdateOutput = "OUTPUT_UPDATE",
   DeleteOutput = "OUTPUT_DELETE",
   AddMiningSchemaFields = "MINING_SCHEMA_ADD",

--- a/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
@@ -15,7 +15,7 @@
  */
 import { ActionMap, Actions } from "./Actions";
 import { HistoryAwareReducer, HistoryService } from "../history";
-import { Output, OutputField } from "@kogito-tooling/pmml-editor-marshaller";
+import { FieldName, Output, OutputField } from "@kogito-tooling/pmml-editor-marshaller";
 import { Reducer } from "react";
 
 interface OutputPayload {
@@ -26,6 +26,10 @@ interface OutputPayload {
   [Actions.DeleteOutput]: {
     readonly modelIndex: number;
     readonly outputIndex: number;
+  };
+  [Actions.AddBatchOutputs]: {
+    readonly modelIndex: number;
+    readonly outputFields: FieldName[];
   };
 }
 
@@ -57,6 +61,15 @@ export const OutputReducer: HistoryAwareReducer<Output, OutputActions> = (
           if (outputIndex >= 0 && outputIndex < draft.OutputField.length) {
             draft.OutputField.splice(outputIndex, 1);
           }
+        });
+      case Actions.AddBatchOutputs:
+        return service.mutate(state, `models[${action.payload.modelIndex}].Output`, draft => {
+          action.payload.outputFields.forEach(name => {
+            draft.OutputField.push({
+              name: name,
+              dataType: "string"
+            });
+          });
         });
     }
 


### PR DESCRIPTION
Hi @manstis,
I choose to use a separate action because the [`commit`](https://github.com/manstis/kogito-tooling/blob/scorecard-poc/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx#L115) callback is already taking care of both adding and editing fields. I did not want to make it more complex. Given that at some point we have to decide a common strategy to manage reducers/actions across the app, I opted for a separate action for now.
